### PR TITLE
Fix back-end: PUT response crashed server

### DIFF
--- a/back-end/routes/Vehicles.js
+++ b/back-end/routes/Vehicles.js
@@ -67,9 +67,8 @@ router.put('/', async (req, res) => {
     if (ok) {
         res.json(req.body);
     } else {
-        res.status(500).json({ error: "Error updating vehicle" });
+      res.status(500).json({ error: "Error updating vehicle" });
     }
-    res.json(result);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
There is a usage of a undeclared variable re-responding the request. It was removed.

In addition, fix indentation of an error response.